### PR TITLE
test: try to create a duplicate account to force duplicate error handling

### DIFF
--- a/test/local/db_tests.js
+++ b/test/local/db_tests.js
@@ -94,7 +94,7 @@ DB.connect(config)
       test(
         'account creation',
         function (t) {
-          t.plan(30)
+          t.plan(31)
           return db.accountExists(ACCOUNT.email)
           .then(function(exists) {
             t.fail('account should not yet exist for this email address')
@@ -158,6 +158,7 @@ DB.connect(config)
               t.equal(err.code, 409)
               t.equal(err.errno, 101)
               t.equal(err.message, 'Record already exists')
+              t.equal(err.error, 'Conflict', 'depends on GH-34 landing', { todo: true })
             }
           )
         }


### PR DESCRIPTION
This will exercise https://github.com/mozilla/fxa-auth-db-server/blob/master/db/mysql.js#L522-531 where it checks the errno. In this case, `err` is not a `RejectionError` as in GH-33, so `err.errno` does equal 1062.
