### PR TITLE
Test on Node v0.11 for the future

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 
 node_js:
  - "0.10"
+ - "0.11"
 
 services:
  - mysql


### PR DESCRIPTION
Since node v0.12 is imminent :question: it might be good to start testing on it so that we know when things don't work. Mainly so we don't end up having to scramble when v0.12 turns into v1 and v0.10 is no longer supported.
