### PR TITLE
Move function to outer scope

### DIFF
--- a/bin/db_server.js
+++ b/bin/db_server.js
@@ -38,14 +38,13 @@ process.on(
   }
 )
 
+function shutdown() {
+  process.nextTick(process.exit)
+}
+
 // defer to allow ass code coverage results to complete processing
 if (process.env.ASS_CODE_COVERAGE) {
   process.on('SIGINT', shutdown)
-  function shutdown() {
-    process.nextTick(function() {
-      process.exit()
-    })
-  }
 }
 
 function startServer(db) {


### PR DESCRIPTION
Since the 'if' doesn't introduce a new scope, it's best if the function is at the top level to stop any misunderstandings. This also stops `grunt jshint` complaining too.
