### PR TITLE
use a version of ass that does not pull in gh-badges at all

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,36 +1,31 @@
 {
   "name": "fxa-auth-db-server",
-  "version": "0.15.0",
+  "version": "0.17.0",
   "dependencies": {
     "ass": {
-      "version": "0.0.7",
-      "from": "ass@git://github.com/dannycoates/ass.git#7d131b5769",
-      "resolved": "git://github.com/dannycoates/ass.git#7d131b57691fe22a848c9ad4b390884f481f442c",
+      "version": "0.0.6",
+      "from": "ass@git://github.com/jrgm/ass.git#2e9a9922f2",
+      "resolved": "git://github.com/jrgm/ass.git#2e9a9922f2b9dd45f65816a961c1aef33fe17f6a",
       "dependencies": {
         "blanket": {
           "version": "1.1.6",
           "from": "blanket@~1.1.5",
-          "resolved": "https://registry.npmjs.org/blanket/-/blanket-1.1.6.tgz",
           "dependencies": {
             "esprima": {
               "version": "1.0.4",
-              "from": "esprima@~1.0.2",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+              "from": "esprima@~1.0.2"
             },
             "falafel": {
               "version": "0.1.6",
-              "from": "falafel@~0.1.6",
-              "resolved": "https://registry.npmjs.org/falafel/-/falafel-0.1.6.tgz"
+              "from": "falafel@~0.1.6"
             },
             "xtend": {
               "version": "2.1.2",
               "from": "xtend@~2.1.1",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
               "dependencies": {
                 "object-keys": {
                   "version": "0.4.0",
-                  "from": "object-keys@~0.4.0",
-                  "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
+                  "from": "object-keys@~0.4.0"
                 }
               }
             }
@@ -39,73 +34,60 @@
         "temp": {
           "version": "0.6.0",
           "from": "temp@~0.6.0",
-          "resolved": "https://registry.npmjs.org/temp/-/temp-0.6.0.tgz",
           "dependencies": {
             "rimraf": {
               "version": "2.1.4",
               "from": "rimraf@~2.1.4",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.1.4.tgz",
               "dependencies": {
                 "graceful-fs": {
                   "version": "1.2.3",
-                  "from": "graceful-fs@~1",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                  "from": "graceful-fs@~1"
                 }
               }
             },
             "osenv": {
               "version": "0.0.3",
-              "from": "osenv@0.0.3",
-              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.0.3.tgz"
+              "from": "osenv@0.0.3"
             }
           }
         },
         "async": {
           "version": "0.2.10",
-          "from": "async@~0.2.9",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+          "from": "async@~0.2.9"
         },
         "cheerio": {
           "version": "0.12.4",
           "from": "cheerio@~0.12.4",
-          "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.12.4.tgz",
           "dependencies": {
             "cheerio-select": {
               "version": "0.0.3",
               "from": "cheerio-select@*",
-              "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-0.0.3.tgz",
               "dependencies": {
                 "CSSselect": {
                   "version": "0.7.0",
                   "from": "CSSselect@0.x",
-                  "resolved": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.7.0.tgz",
                   "dependencies": {
                     "CSSwhat": {
                       "version": "0.4.7",
-                      "from": "CSSwhat@0.4",
-                      "resolved": "https://registry.npmjs.org/CSSwhat/-/CSSwhat-0.4.7.tgz"
+                      "from": "CSSwhat@0.4"
                     },
                     "domutils": {
                       "version": "1.4.3",
                       "from": "domutils@1.4",
-                      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
                       "dependencies": {
                         "domelementtype": {
                           "version": "1.1.1",
-                          "from": "domelementtype@1",
-                          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.1.tgz"
+                          "from": "domelementtype@1"
                         }
                       }
                     },
                     "boolbase": {
                       "version": "1.0.0",
-                      "from": "boolbase@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz"
+                      "from": "boolbase@~1.0.0"
                     },
                     "nth-check": {
                       "version": "1.0.0",
-                      "from": "nth-check@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.0.tgz"
+                      "from": "nth-check@~1.0.0"
                     }
                   }
                 }
@@ -114,47 +96,38 @@
             "htmlparser2": {
               "version": "3.1.4",
               "from": "htmlparser2@3.1.4",
-              "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.1.4.tgz",
               "dependencies": {
                 "domhandler": {
                   "version": "2.0.3",
-                  "from": "domhandler@2.0",
-                  "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.0.3.tgz"
+                  "from": "domhandler@2.0"
                 },
                 "domutils": {
                   "version": "1.1.6",
-                  "from": "domutils@1.1",
-                  "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz"
+                  "from": "domutils@1.1"
                 },
                 "domelementtype": {
                   "version": "1.1.1",
-                  "from": "domelementtype@1",
-                  "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.1.tgz"
+                  "from": "domelementtype@1"
                 },
                 "readable-stream": {
                   "version": "1.0.27-1",
                   "from": "readable-stream@1.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                      "from": "core-util-is@~1.0.0"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                      "from": "isarray@0.0.1"
                     },
                     "string_decoder": {
                       "version": "0.10.25-1",
-                      "from": "string_decoder@~0.10.x",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz"
+                      "from": "string_decoder@~0.10.x"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@~2.0.1",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "from": "inherits@~2.0.1"
                     }
                   }
                 }
@@ -162,542 +135,11 @@
             },
             "underscore": {
               "version": "1.4.4",
-              "from": "underscore@~1.4",
-              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
+              "from": "underscore@~1.4"
             },
             "entities": {
               "version": "0.5.0",
-              "from": "entities@0.x",
-              "resolved": "https://registry.npmjs.org/entities/-/entities-0.5.0.tgz"
-            }
-          }
-        },
-        "gh-badges": {
-          "version": "0.2.3",
-          "from": "gh-badges@~0.2.1",
-          "resolved": "https://registry.npmjs.org/gh-badges/-/gh-badges-0.2.3.tgz",
-          "dependencies": {
-            "dot": {
-              "version": "1.0.2",
-              "from": "dot@~1.0.2",
-              "resolved": "https://registry.npmjs.org/dot/-/dot-1.0.2.tgz"
-            },
-            "svgo": {
-              "version": "0.4.4",
-              "from": "svgo@~0.4.2",
-              "resolved": "https://registry.npmjs.org/svgo/-/svgo-0.4.4.tgz",
-              "dependencies": {
-                "sax": {
-                  "version": "0.6.0",
-                  "from": "sax@~0.6.0",
-                  "resolved": "https://registry.npmjs.org/sax/-/sax-0.6.0.tgz"
-                },
-                "coa": {
-                  "version": "0.4.1",
-                  "from": "coa@~0.4.0",
-                  "resolved": "https://registry.npmjs.org/coa/-/coa-0.4.1.tgz",
-                  "dependencies": {
-                    "q": {
-                      "version": "0.9.7",
-                      "from": "q@~0.9.6",
-                      "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
-                    }
-                  }
-                },
-                "js-yaml": {
-                  "version": "2.1.3",
-                  "from": "js-yaml@~2.1.0",
-                  "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.1.3.tgz",
-                  "dependencies": {
-                    "argparse": {
-                      "version": "0.1.15",
-                      "from": "argparse@~ 0.1.11",
-                      "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.15.tgz",
-                      "dependencies": {
-                        "underscore": {
-                          "version": "1.4.4",
-                          "from": "underscore@~1.4.3",
-                          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
-                        },
-                        "underscore.string": {
-                          "version": "2.3.3",
-                          "from": "underscore.string@~2.3.1",
-                          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
-                        }
-                      }
-                    },
-                    "esprima": {
-                      "version": "1.0.4",
-                      "from": "esprima@~ 1.0.2",
-                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
-                    }
-                  }
-                },
-                "colors": {
-                  "version": "0.6.2",
-                  "from": "colors@~0.6.0",
-                  "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
-                },
-                "whet.extend": {
-                  "version": "0.9.9",
-                  "from": "whet.extend@",
-                  "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz"
-                }
-              }
-            },
-            "phantomjs": {
-              "version": "1.9.7-14",
-              "from": "phantomjs@~1.9.2-6",
-              "resolved": "https://registry.npmjs.org/phantomjs/-/phantomjs-1.9.7-14.tgz",
-              "dependencies": {
-                "adm-zip": {
-                  "version": "0.2.1",
-                  "from": "adm-zip@0.2.1",
-                  "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.2.1.tgz"
-                },
-                "kew": {
-                  "version": "0.1.7",
-                  "from": "kew@~0.1.7",
-                  "resolved": "https://registry.npmjs.org/kew/-/kew-0.1.7.tgz"
-                },
-                "ncp": {
-                  "version": "0.4.2",
-                  "from": "ncp@0.4.2",
-                  "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz"
-                },
-                "npmconf": {
-                  "version": "0.0.24",
-                  "from": "npmconf@0.0.24",
-                  "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-0.0.24.tgz",
-                  "dependencies": {
-                    "config-chain": {
-                      "version": "1.1.8",
-                      "from": "config-chain@~1.1.1",
-                      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.8.tgz",
-                      "dependencies": {
-                        "proto-list": {
-                          "version": "1.2.3",
-                          "from": "proto-list@~1.2.1",
-                          "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.3.tgz"
-                        }
-                      }
-                    },
-                    "inherits": {
-                      "version": "1.0.0",
-                      "from": "inherits@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
-                    },
-                    "once": {
-                      "version": "1.1.1",
-                      "from": "once@~1.1.1",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
-                    },
-                    "osenv": {
-                      "version": "0.0.3",
-                      "from": "osenv@0.0.3",
-                      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.0.3.tgz"
-                    },
-                    "nopt": {
-                      "version": "2.2.1",
-                      "from": "nopt@2",
-                      "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
-                      "dependencies": {
-                        "abbrev": {
-                          "version": "1.0.5",
-                          "from": "abbrev@1",
-                          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
-                        }
-                      }
-                    },
-                    "semver": {
-                      "version": "1.1.4",
-                      "from": "semver@~1.1.0",
-                      "resolved": "https://registry.npmjs.org/semver/-/semver-1.1.4.tgz"
-                    },
-                    "ini": {
-                      "version": "1.1.0",
-                      "from": "ini@~1.1.0",
-                      "resolved": "https://registry.npmjs.org/ini/-/ini-1.1.0.tgz"
-                    }
-                  }
-                },
-                "mkdirp": {
-                  "version": "0.3.5",
-                  "from": "mkdirp@0.3.5",
-                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
-                },
-                "progress": {
-                  "version": "1.1.7",
-                  "from": "progress@^1.1.5",
-                  "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.7.tgz"
-                },
-                "request-progress": {
-                  "version": "0.3.1",
-                  "from": "request-progress@^0.3.1",
-                  "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
-                  "dependencies": {
-                    "throttleit": {
-                      "version": "0.0.2",
-                      "from": "throttleit@~0.0.2",
-                      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz"
-                    }
-                  }
-                },
-                "rimraf": {
-                  "version": "2.2.8",
-                  "from": "rimraf@~2.2.2",
-                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
-                },
-                "which": {
-                  "version": "1.0.5",
-                  "from": "which@~1.0.5",
-                  "resolved": "https://registry.npmjs.org/which/-/which-1.0.5.tgz"
-                }
-              }
-            },
-            "es6-promise": {
-              "version": "0.1.2",
-              "from": "es6-promise@~0.1.1",
-              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-0.1.2.tgz"
-            },
-            "camp": {
-              "version": "13.11.9",
-              "from": "camp@~13.11.9",
-              "resolved": "https://registry.npmjs.org/camp/-/camp-13.11.9.tgz",
-              "dependencies": {
-                "socket.io": {
-                  "version": "1.0.6",
-                  "from": "socket.io@>=0.9.13",
-                  "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.0.6.tgz",
-                  "dependencies": {
-                    "engine.io": {
-                      "version": "1.3.1",
-                      "from": "engine.io@1.3.1",
-                      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.3.1.tgz",
-                      "dependencies": {
-                        "debug": {
-                          "version": "0.6.0",
-                          "from": "debug@0.6.0",
-                          "resolved": "https://registry.npmjs.org/debug/-/debug-0.6.0.tgz"
-                        },
-                        "engine.io-parser": {
-                          "version": "1.0.6",
-                          "from": "engine.io-parser@1.0.6",
-                          "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.0.6.tgz",
-                          "dependencies": {
-                            "base64-arraybuffer": {
-                              "version": "0.1.2",
-                              "from": "base64-arraybuffer@0.1.2",
-                              "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz"
-                            },
-                            "after": {
-                              "version": "0.8.1",
-                              "from": "after@0.8.1",
-                              "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz"
-                            },
-                            "arraybuffer.slice": {
-                              "version": "0.0.6",
-                              "from": "arraybuffer.slice@0.0.6",
-                              "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz"
-                            },
-                            "blob": {
-                              "version": "0.0.2",
-                              "from": "blob@0.0.2",
-                              "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.2.tgz"
-                            },
-                            "utf8": {
-                              "version": "2.0.0",
-                              "from": "utf8@2.0.0",
-                              "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "base64id": {
-                          "version": "0.1.0",
-                          "from": "base64id@0.1.0",
-                          "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz"
-                        }
-                      }
-                    },
-                    "socket.io-parser": {
-                      "version": "2.2.0",
-                      "from": "socket.io-parser@2.2.0",
-                      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.0.tgz",
-                      "dependencies": {
-                        "json3": {
-                          "version": "3.2.6",
-                          "from": "json3@3.2.6",
-                          "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz"
-                        },
-                        "emitter": {
-                          "version": "1.0.1",
-                          "from": "http://github.com/component/emitter/archive/1.0.1.tar.gz",
-                          "resolved": "http://github.com/component/emitter/archive/1.0.1.tar.gz",
-                          "dependencies": {
-                            "indexof": {
-                              "version": "0.0.1",
-                              "from": "indexof@0.0.1",
-                              "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
-                            }
-                          }
-                        },
-                        "isarray": {
-                          "version": "0.0.1",
-                          "from": "isarray@0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                        }
-                      }
-                    },
-                    "socket.io-client": {
-                      "version": "1.0.6",
-                      "from": "socket.io-client@1.0.6",
-                      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.0.6.tgz",
-                      "dependencies": {
-                        "engine.io-client": {
-                          "version": "1.3.1",
-                          "from": "engine.io-client@1.3.1",
-                          "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.3.1.tgz",
-                          "dependencies": {
-                            "has-cors": {
-                              "version": "1.0.3",
-                              "from": "has-cors@1.0.3",
-                              "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.0.3.tgz",
-                              "dependencies": {
-                                "global": {
-                                  "version": "2.0.1",
-                                  "from": "https://github.com/component/global/archive/v2.0.1.tar.gz",
-                                  "resolved": "https://github.com/component/global/archive/v2.0.1.tar.gz"
-                                }
-                              }
-                            },
-                            "xmlhttprequest": {
-                              "version": "1.5.0",
-                              "from": "https://github.com/LearnBoost/node-XMLHttpRequest/archive/0f36d0b5ebc03d85f860d42a64ae9791e1daa433.tar.gz",
-                              "resolved": "https://github.com/LearnBoost/node-XMLHttpRequest/archive/0f36d0b5ebc03d85f860d42a64ae9791e1daa433.tar.gz"
-                            },
-                            "engine.io-parser": {
-                              "version": "1.0.6",
-                              "from": "engine.io-parser@1.0.6",
-                              "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.0.6.tgz",
-                              "dependencies": {
-                                "base64-arraybuffer": {
-                                  "version": "0.1.2",
-                                  "from": "base64-arraybuffer@0.1.2",
-                                  "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz"
-                                },
-                                "after": {
-                                  "version": "0.8.1",
-                                  "from": "after@0.8.1",
-                                  "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz"
-                                },
-                                "arraybuffer.slice": {
-                                  "version": "0.0.6",
-                                  "from": "arraybuffer.slice@0.0.6",
-                                  "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz"
-                                },
-                                "blob": {
-                                  "version": "0.0.2",
-                                  "from": "blob@0.0.2",
-                                  "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.2.tgz"
-                                },
-                                "utf8": {
-                                  "version": "2.0.0",
-                                  "from": "utf8@2.0.0",
-                                  "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "parsejson": {
-                              "version": "0.0.1",
-                              "from": "parsejson@0.0.1",
-                              "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.1.tgz",
-                              "dependencies": {
-                                "better-assert": {
-                                  "version": "1.0.0",
-                                  "from": "better-assert@~1.0.0",
-                                  "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.0.tgz",
-                                  "dependencies": {
-                                    "callsite": {
-                                      "version": "1.0.0",
-                                      "from": "callsite@1.0.0",
-                                      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "parseqs": {
-                              "version": "0.0.2",
-                              "from": "parseqs@0.0.2",
-                              "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.2.tgz",
-                              "dependencies": {
-                                "better-assert": {
-                                  "version": "1.0.0",
-                                  "from": "better-assert@~1.0.0",
-                                  "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.0.tgz",
-                                  "dependencies": {
-                                    "callsite": {
-                                      "version": "1.0.0",
-                                      "from": "callsite@1.0.0",
-                                      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "component-inherit": {
-                              "version": "0.0.3",
-                              "from": "component-inherit@0.0.3",
-                              "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz"
-                            }
-                          }
-                        },
-                        "component-bind": {
-                          "version": "1.0.0",
-                          "from": "component-bind@1.0.0",
-                          "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz"
-                        },
-                        "component-emitter": {
-                          "version": "1.1.2",
-                          "from": "component-emitter@1.1.2",
-                          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
-                        },
-                        "object-component": {
-                          "version": "0.0.3",
-                          "from": "object-component@0.0.3",
-                          "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz"
-                        },
-                        "indexof": {
-                          "version": "0.0.1",
-                          "from": "indexof@0.0.1",
-                          "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
-                        },
-                        "parseuri": {
-                          "version": "0.0.2",
-                          "from": "parseuri@0.0.2",
-                          "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.2.tgz",
-                          "dependencies": {
-                            "better-assert": {
-                              "version": "1.0.0",
-                              "from": "better-assert@~1.0.0",
-                              "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.0.tgz",
-                              "dependencies": {
-                                "callsite": {
-                                  "version": "1.0.0",
-                                  "from": "callsite@1.0.0",
-                                  "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "to-array": {
-                          "version": "0.1.3",
-                          "from": "to-array@0.1.3",
-                          "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.3.tgz"
-                        }
-                      }
-                    },
-                    "socket.io-adapter": {
-                      "version": "0.2.0",
-                      "from": "socket.io-adapter@0.2.0",
-                      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.2.0.tgz",
-                      "dependencies": {
-                        "socket.io-parser": {
-                          "version": "2.1.2",
-                          "from": "socket.io-parser@2.1.2",
-                          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.1.2.tgz",
-                          "dependencies": {
-                            "json3": {
-                              "version": "3.2.6",
-                              "from": "json3@3.2.6",
-                              "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz"
-                            },
-                            "emitter": {
-                              "version": "1.0.1",
-                              "from": "http://github.com/component/emitter/archive/1.0.1.tar.gz",
-                              "resolved": "http://github.com/component/emitter/archive/1.0.1.tar.gz",
-                              "dependencies": {
-                                "indexof": {
-                                  "version": "0.0.1",
-                                  "from": "indexof@0.0.1",
-                                  "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
-                                }
-                              }
-                            },
-                            "isarray": {
-                              "version": "0.0.1",
-                              "from": "isarray@0.0.1",
-                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "has-binary-data": {
-                      "version": "0.1.1",
-                      "from": "has-binary-data@0.1.1",
-                      "resolved": "https://registry.npmjs.org/has-binary-data/-/has-binary-data-0.1.1.tgz",
-                      "dependencies": {
-                        "isarray": {
-                          "version": "0.0.1",
-                          "from": "isarray@0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                        }
-                      }
-                    },
-                    "debug": {
-                      "version": "0.7.4",
-                      "from": "debug@0.7.4",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
-                    }
-                  }
-                },
-                "ws": {
-                  "version": "0.4.31",
-                  "from": "ws@>=0.4.29",
-                  "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.31.tgz",
-                  "dependencies": {
-                    "commander": {
-                      "version": "0.6.1",
-                      "from": "commander@~0.6.1",
-                      "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
-                    },
-                    "nan": {
-                      "version": "0.3.2",
-                      "from": "nan@~0.3.0",
-                      "resolved": "https://registry.npmjs.org/nan/-/nan-0.3.2.tgz"
-                    },
-                    "tinycolor": {
-                      "version": "0.0.1",
-                      "from": "tinycolor@0.x",
-                      "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
-                    },
-                    "options": {
-                      "version": "0.0.5",
-                      "from": "options@>=0.0.5",
-                      "resolved": "https://registry.npmjs.org/options/-/options-0.0.5.tgz"
-                    }
-                  }
-                },
-                "formidable": {
-                  "version": "1.0.15",
-                  "from": "formidable@>=1.0.13",
-                  "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.15.tgz"
-                },
-                "fleau": {
-                  "version": "13.7.22",
-                  "from": "fleau@>=13.04.27",
-                  "resolved": "https://registry.npmjs.org/fleau/-/fleau-13.7.22.tgz",
-                  "dependencies": {
-                    "localeval": {
-                      "version": "13.12.11",
-                      "from": "localeval@>=13.04.14",
-                      "resolved": "https://registry.npmjs.org/localeval/-/localeval-13.12.11.tgz"
-                    }
-                  }
-                }
-              }
+              "from": "entities@0.x"
             }
           }
         }
@@ -705,109 +147,89 @@
     },
     "bluebird": {
       "version": "1.2.2",
-      "from": "bluebird@1.2.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-1.2.2.tgz"
+      "from": "bluebird@1.2.2"
     },
     "bunyan": {
       "version": "0.22.3",
       "from": "bunyan@0.22.3",
-      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-0.22.3.tgz",
       "dependencies": {
         "mv": {
           "version": "2.0.1",
           "from": "mv@~2",
-          "resolved": "https://registry.npmjs.org/mv/-/mv-2.0.1.tgz",
           "dependencies": {
             "mkdirp": {
               "version": "0.5.0",
               "from": "mkdirp@~0.5.0",
-              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
               "dependencies": {
                 "minimist": {
                   "version": "0.0.8",
-                  "from": "minimist@0.0.8",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                  "from": "minimist@0.0.8"
                 }
               }
             },
             "ncp": {
               "version": "0.5.1",
-              "from": "ncp@~0.5.1",
-              "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.5.1.tgz"
+              "from": "ncp@~0.5.1"
             },
             "rimraf": {
               "version": "2.2.8",
-              "from": "rimraf@~2.2.8",
-              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+              "from": "rimraf@~2.2.8"
             }
           }
         },
         "dtrace-provider": {
           "version": "0.2.8",
-          "from": "dtrace-provider@0.2.8",
-          "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.2.8.tgz"
+          "from": "dtrace-provider@0.2.8"
         }
       }
     },
     "grunt": {
       "version": "0.4.5",
       "from": "grunt@0.4.5",
-      "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.5.tgz",
       "dependencies": {
         "async": {
           "version": "0.1.22",
-          "from": "async@~0.1.22",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
+          "from": "async@~0.1.22"
         },
         "coffee-script": {
           "version": "1.3.3",
-          "from": "coffee-script@~1.3.3",
-          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
+          "from": "coffee-script@~1.3.3"
         },
         "colors": {
           "version": "0.6.2",
-          "from": "colors@~0.6.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
+          "from": "colors@~0.6.2"
         },
         "dateformat": {
           "version": "1.0.2-1.2.3",
-          "from": "dateformat@1.0.2-1.2.3",
-          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz"
+          "from": "dateformat@1.0.2-1.2.3"
         },
         "eventemitter2": {
           "version": "0.4.14",
-          "from": "eventemitter2@~0.4.13",
-          "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
+          "from": "eventemitter2@~0.4.13"
         },
         "findup-sync": {
           "version": "0.1.3",
           "from": "findup-sync@~0.1.2",
-          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
               "from": "glob@~3.2.9",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "from": "inherits@2"
                 },
                 "minimatch": {
                   "version": "0.3.0",
                   "from": "minimatch@0.3",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "lru-cache@2",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                      "from": "lru-cache@2"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "sigmund@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                      "from": "sigmund@~1.0.0"
                     }
                   }
                 }
@@ -815,145 +237,119 @@
             },
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@~2.4.1",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+              "from": "lodash@~2.4.1"
             }
           }
         },
         "glob": {
           "version": "3.1.21",
           "from": "glob@~3.1.21",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
           "dependencies": {
             "graceful-fs": {
               "version": "1.2.3",
-              "from": "graceful-fs@~1",
-              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+              "from": "graceful-fs@~1"
             },
             "inherits": {
               "version": "1.0.0",
-              "from": "inherits@1",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
+              "from": "inherits@1"
             }
           }
         },
         "hooker": {
           "version": "0.2.3",
-          "from": "hooker@~0.2.3",
-          "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
+          "from": "hooker@~0.2.3"
         },
         "iconv-lite": {
           "version": "0.2.11",
-          "from": "iconv-lite@~0.2.11",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
+          "from": "iconv-lite@~0.2.11"
         },
         "minimatch": {
           "version": "0.2.14",
           "from": "minimatch@~0.2.14",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "dependencies": {
             "lru-cache": {
               "version": "2.5.0",
-              "from": "lru-cache@2",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+              "from": "lru-cache@2"
             },
             "sigmund": {
               "version": "1.0.0",
-              "from": "sigmund@~1.0.0",
-              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+              "from": "sigmund@~1.0.0"
             }
           }
         },
         "nopt": {
           "version": "1.0.10",
           "from": "nopt@~1.0.10",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.5",
-              "from": "abbrev@1",
-              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+              "from": "abbrev@1"
             }
           }
         },
         "rimraf": {
           "version": "2.2.8",
-          "from": "rimraf@~2.2.8",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+          "from": "rimraf@~2.2.8"
         },
         "lodash": {
           "version": "0.9.2",
-          "from": "lodash@~0.9.2",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
+          "from": "lodash@~0.9.2"
         },
         "underscore.string": {
           "version": "2.2.1",
-          "from": "underscore.string@~2.2.1",
-          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz"
+          "from": "underscore.string@~2.2.1"
         },
         "which": {
           "version": "1.0.5",
-          "from": "which@~1.0.5",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.0.5.tgz"
+          "from": "which@~1.0.5"
         },
         "js-yaml": {
           "version": "2.0.5",
           "from": "js-yaml@~2.0.5",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-2.0.5.tgz",
           "dependencies": {
             "argparse": {
               "version": "0.1.15",
               "from": "argparse@~ 0.1.11",
-              "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.15.tgz",
               "dependencies": {
                 "underscore": {
                   "version": "1.4.4",
-                  "from": "underscore@~1.4.3",
-                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
+                  "from": "underscore@~1.4.3"
                 },
                 "underscore.string": {
                   "version": "2.3.3",
-                  "from": "underscore.string@~2.3.1",
-                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                  "from": "underscore.string@~2.3.1"
                 }
               }
             },
             "esprima": {
               "version": "1.0.4",
-              "from": "esprima@~ 1.0.2",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+              "from": "esprima@~ 1.0.2"
             }
           }
         },
         "exit": {
           "version": "0.1.2",
-          "from": "exit@~0.1.1",
-          "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+          "from": "exit@~0.1.1"
         },
         "getobject": {
           "version": "0.1.0",
-          "from": "getobject@~0.1.0",
-          "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz"
+          "from": "getobject@~0.1.0"
         },
         "grunt-legacy-util": {
           "version": "0.2.0",
-          "from": "grunt-legacy-util@~0.2.0",
-          "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz"
+          "from": "grunt-legacy-util@~0.2.0"
         },
         "grunt-legacy-log": {
           "version": "0.1.1",
           "from": "grunt-legacy-log@~0.1.0",
-          "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.1.tgz",
           "dependencies": {
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@~2.4.1",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+              "from": "lodash@~2.4.1"
             },
             "underscore.string": {
               "version": "2.3.3",
-              "from": "underscore.string@~2.3.3",
-              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+              "from": "underscore.string@~2.3.3"
             }
           }
         }
@@ -962,183 +358,164 @@
     "grunt-contrib-jshint": {
       "version": "0.10.0",
       "from": "grunt-contrib-jshint@0.10.0",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-0.10.0.tgz",
       "dependencies": {
         "jshint": {
           "version": "2.5.2",
           "from": "jshint@~2.5.0",
-          "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.5.2.tgz",
           "dependencies": {
             "shelljs": {
               "version": "0.3.0",
-              "from": "shelljs@0.3.x",
-              "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
+              "from": "shelljs@0.3.x"
             },
             "underscore": {
               "version": "1.6.0",
-              "from": "underscore@1.6.x",
-              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
+              "from": "underscore@1.6.x"
             },
             "cli": {
               "version": "0.6.3",
               "from": "cli@0.6.x",
-              "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.3.tgz",
               "dependencies": {
                 "glob": {
                   "version": "3.2.11",
                   "from": "glob@~ 3.2.1",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
                   "dependencies": {
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@2",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "from": "inherits@2"
+                    },
+                    "minimatch": {
+                      "version": "0.3.0",
+                      "from": "minimatch@0.3",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.5.0",
+                          "from": "lru-cache@2"
+                        },
+                        "sigmund": {
+                          "version": "1.0.0",
+                          "from": "sigmund@~1.0.0"
+                        }
+                      }
                     }
                   }
                 }
               }
             },
             "minimatch": {
-              "version": "0.3.0",
+              "version": "0.4.0",
               "from": "minimatch@0.x.x",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "lru-cache@2",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                  "from": "lru-cache@2"
                 },
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "sigmund@~1.0.0",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                  "from": "sigmund@~1.0.0"
                 }
               }
             },
             "htmlparser2": {
               "version": "3.7.3",
               "from": "htmlparser2@3.7.x",
-              "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.7.3.tgz",
               "dependencies": {
                 "domhandler": {
                   "version": "2.2.0",
-                  "from": "domhandler@2.2",
-                  "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.2.0.tgz"
+                  "from": "domhandler@2.2"
                 },
                 "domutils": {
                   "version": "1.5.0",
-                  "from": "domutils@1.5",
-                  "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.0.tgz"
+                  "from": "domutils@1.5"
                 },
                 "domelementtype": {
                   "version": "1.1.1",
-                  "from": "domelementtype@1",
-                  "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.1.tgz"
+                  "from": "domelementtype@1"
                 },
                 "readable-stream": {
                   "version": "1.1.13-1",
                   "from": "readable-stream@1.1",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13-1.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                      "from": "core-util-is@~1.0.0"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                      "from": "isarray@0.0.1"
                     },
                     "string_decoder": {
                       "version": "0.10.25-1",
-                      "from": "string_decoder@~0.10.x",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz"
+                      "from": "string_decoder@~0.10.x"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@~2.0.1",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "from": "inherits@~2.0.1"
                     }
                   }
                 },
                 "entities": {
                   "version": "1.0.0",
-                  "from": "entities@1.0",
-                  "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
+                  "from": "entities@1.0"
                 }
               }
             },
             "console-browserify": {
               "version": "1.1.0",
               "from": "console-browserify@1.1.x",
-              "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
               "dependencies": {
                 "date-now": {
                   "version": "0.1.4",
-                  "from": "date-now@^0.1.4",
-                  "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+                  "from": "date-now@^0.1.4"
                 }
               }
             },
             "exit": {
               "version": "0.1.2",
-              "from": "exit@0.1.x",
-              "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+              "from": "exit@0.1.x"
             },
             "strip-json-comments": {
               "version": "0.1.3",
-              "from": "strip-json-comments@0.1.x",
-              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+              "from": "strip-json-comments@0.1.x"
             }
           }
         },
         "hooker": {
           "version": "0.2.3",
-          "from": "hooker@~0.2.3",
-          "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
+          "from": "hooker@~0.2.3"
         }
       }
     },
     "grunt-copyright": {
       "version": "0.1.0",
-      "from": "grunt-copyright@0.1.0",
-      "resolved": "https://registry.npmjs.org/grunt-copyright/-/grunt-copyright-0.1.0.tgz"
+      "from": "grunt-copyright@0.1.0"
     },
     "load-grunt-tasks": {
       "version": "0.4.0",
       "from": "load-grunt-tasks@0.4.0",
-      "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-0.4.0.tgz",
       "dependencies": {
         "findup-sync": {
           "version": "0.1.3",
-          "from": "findup-sync@^0.1.2",
-          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+          "from": "findup-sync@~0.1.2",
           "dependencies": {
             "glob": {
               "version": "3.2.11",
               "from": "glob@~3.2.9",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "from": "inherits@2"
                 },
                 "minimatch": {
                   "version": "0.3.0",
                   "from": "minimatch@0.3",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "lru-cache@2",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                      "from": "lru-cache@2"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "sigmund@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                      "from": "sigmund@~1.0.0"
                     }
                   }
                 }
@@ -1146,35 +523,29 @@
             },
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@~2.4.1",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+              "from": "lodash@~2.4.1"
             }
           }
         },
         "multimatch": {
           "version": "0.1.0",
           "from": "multimatch@^0.1.0",
-          "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-0.1.0.tgz",
           "dependencies": {
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@~2.4.1",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+              "from": "lodash@~2.4.1"
             },
             "minimatch": {
               "version": "0.2.14",
               "from": "minimatch@~0.2.14",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "lru-cache@2",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                  "from": "lru-cache@2"
                 },
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "sigmund@~1.0.0",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                  "from": "sigmund@~1.0.0"
                 }
               }
             }
@@ -1185,42 +556,34 @@
     "mysql": {
       "version": "2.1.1",
       "from": "mysql@2.1.1",
-      "resolved": "https://registry.npmjs.org/mysql/-/mysql-2.1.1.tgz",
       "dependencies": {
         "require-all": {
           "version": "0.0.3",
-          "from": "require-all@0.0.3",
-          "resolved": "https://registry.npmjs.org/require-all/-/require-all-0.0.3.tgz"
+          "from": "require-all@0.0.3"
         },
         "bignumber.js": {
           "version": "1.0.1",
-          "from": "bignumber.js@1.0.1",
-          "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-1.0.1.tgz"
+          "from": "bignumber.js@1.0.1"
         },
         "readable-stream": {
           "version": "1.1.13-1",
-          "from": "readable-stream@1.1",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13-1.tgz",
+          "from": "readable-stream@~1.1.9",
           "dependencies": {
             "core-util-is": {
               "version": "1.0.1",
-              "from": "core-util-is@~1.0.0",
-              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+              "from": "core-util-is@~1.0.0"
             },
             "isarray": {
               "version": "0.0.1",
-              "from": "isarray@0.0.1",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+              "from": "isarray@0.0.1"
             },
             "string_decoder": {
               "version": "0.10.25-1",
-              "from": "string_decoder@~0.10.x",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.25-1.tgz"
+              "from": "string_decoder@~0.10.x"
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@~2.0.1",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+              "from": "inherits@~2.0.1"
             }
           }
         }
@@ -1229,299 +592,244 @@
     "rc": {
       "version": "0.3.4",
       "from": "rc@0.3.4",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-0.3.4.tgz",
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "from": "minimist@~0.0.7",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+          "from": "minimist@~0.0.7"
         },
         "deep-extend": {
           "version": "0.2.10",
-          "from": "deep-extend@~0.2.5",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.10.tgz"
+          "from": "deep-extend@~0.2.5"
         },
         "ini": {
           "version": "1.1.0",
-          "from": "ini@~1.1.0",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.1.0.tgz"
+          "from": "ini@~1.1.0"
         }
       }
     },
     "request": {
       "version": "2.36.0",
       "from": "request@2.36.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.36.0.tgz",
       "dependencies": {
         "qs": {
           "version": "0.6.6",
-          "from": "qs@~0.6.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
+          "from": "qs@~0.6.0"
         },
         "json-stringify-safe": {
           "version": "5.0.0",
-          "from": "json-stringify-safe@~5.0.0",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+          "from": "json-stringify-safe@~5.0.0"
         },
         "mime": {
           "version": "1.2.11",
-          "from": "mime@~1.2.9",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+          "from": "mime@~1.2.9"
         },
         "forever-agent": {
           "version": "0.5.2",
-          "from": "forever-agent@~0.5.0",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+          "from": "forever-agent@~0.5.0"
         },
         "node-uuid": {
           "version": "1.4.1",
-          "from": "node-uuid@~1.4.0",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
+          "from": "node-uuid@~1.4.0"
         },
         "tough-cookie": {
           "version": "0.12.1",
           "from": "tough-cookie@>=0.12.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
           "dependencies": {
             "punycode": {
               "version": "1.3.0",
-              "from": "punycode@>=0.2.0",
-              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.0.tgz"
+              "from": "punycode@>=0.2.0"
             }
           }
         },
         "form-data": {
           "version": "0.1.4",
           "from": "form-data@~0.1.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
           "dependencies": {
             "combined-stream": {
               "version": "0.0.5",
               "from": "combined-stream@~0.0.4",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.5.tgz",
               "dependencies": {
                 "delayed-stream": {
                   "version": "0.0.5",
-                  "from": "delayed-stream@0.0.5",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                  "from": "delayed-stream@0.0.5"
                 }
               }
             },
             "async": {
               "version": "0.9.0",
-              "from": "async@~0.9.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+              "from": "async@~0.9.0"
             }
           }
         },
         "tunnel-agent": {
           "version": "0.4.0",
-          "from": "tunnel-agent@~0.4.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+          "from": "tunnel-agent@~0.4.0"
         },
         "http-signature": {
           "version": "0.10.0",
           "from": "http-signature@~0.10.0",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
           "dependencies": {
             "assert-plus": {
               "version": "0.1.2",
-              "from": "assert-plus@0.1.2",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
+              "from": "assert-plus@0.1.2"
             },
             "asn1": {
               "version": "0.1.11",
-              "from": "asn1@0.1.11",
-              "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+              "from": "asn1@0.1.11"
             },
             "ctype": {
               "version": "0.5.2",
-              "from": "ctype@0.5.2",
-              "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
+              "from": "ctype@0.5.2"
             }
           }
         },
         "oauth-sign": {
           "version": "0.3.0",
-          "from": "oauth-sign@~0.3.0",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
+          "from": "oauth-sign@~0.3.0"
         },
         "hawk": {
           "version": "1.0.0",
           "from": "hawk@~1.0.0",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
           "dependencies": {
             "hoek": {
               "version": "0.9.1",
-              "from": "hoek@0.9.x",
-              "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+              "from": "hoek@0.9.x"
             },
             "boom": {
               "version": "0.4.2",
-              "from": "boom@0.4.x",
-              "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+              "from": "boom@0.4.x"
             },
             "cryptiles": {
               "version": "0.2.2",
-              "from": "cryptiles@0.2.x",
-              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+              "from": "cryptiles@0.2.x"
             },
             "sntp": {
               "version": "0.2.4",
-              "from": "sntp@0.2.x",
-              "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+              "from": "sntp@0.2.x"
             }
           }
         },
         "aws-sign2": {
           "version": "0.5.0",
-          "from": "aws-sign2@~0.5.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+          "from": "aws-sign2@~0.5.0"
         }
       }
     },
     "restify": {
       "version": "2.7.0",
       "from": "restify@2.7.0",
-      "resolved": "https://registry.npmjs.org/restify/-/restify-2.7.0.tgz",
       "dependencies": {
         "assert-plus": {
           "version": "0.1.5",
-          "from": "assert-plus@0.1.5",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+          "from": "assert-plus@0.1.5"
         },
         "backoff": {
           "version": "2.3.0",
-          "from": "backoff@2.3.0",
-          "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.3.0.tgz"
+          "from": "backoff@2.3.0"
         },
         "bunyan": {
           "version": "0.22.1",
           "from": "bunyan@0.22.1",
-          "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-0.22.1.tgz",
           "dependencies": {
             "mv": {
               "version": "0.0.5",
-              "from": "mv@0.0.5",
-              "resolved": "https://registry.npmjs.org/mv/-/mv-0.0.5.tgz"
+              "from": "mv@0.0.5"
             }
           }
         },
         "csv": {
           "version": "0.3.7",
-          "from": "csv@0.3.7",
-          "resolved": "https://registry.npmjs.org/csv/-/csv-0.3.7.tgz"
+          "from": "csv@0.3.7"
         },
         "deep-equal": {
           "version": "0.0.0",
-          "from": "deep-equal@~0.0.0",
-          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz"
+          "from": "deep-equal@~0.0.0"
         },
         "escape-regexp-component": {
           "version": "1.0.2",
-          "from": "escape-regexp-component@1.0.2",
-          "resolved": "https://registry.npmjs.org/escape-regexp-component/-/escape-regexp-component-1.0.2.tgz"
+          "from": "escape-regexp-component@1.0.2"
         },
         "formidable": {
           "version": "1.0.14",
-          "from": "formidable@1.0.14",
-          "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.14.tgz"
+          "from": "formidable@1.0.14"
         },
         "http-signature": {
           "version": "0.10.0",
           "from": "http-signature@0.10.0",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.0.tgz",
           "dependencies": {
             "assert-plus": {
               "version": "0.1.2",
-              "from": "assert-plus@0.1.2",
-              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
+              "from": "assert-plus@0.1.2"
             },
             "asn1": {
               "version": "0.1.11",
-              "from": "asn1@0.1.11",
-              "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+              "from": "asn1@0.1.11"
             },
             "ctype": {
               "version": "0.5.2",
-              "from": "ctype@0.5.2",
-              "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
+              "from": "ctype@0.5.2"
             }
           }
         },
         "keep-alive-agent": {
           "version": "0.0.1",
-          "from": "keep-alive-agent@0.0.1",
-          "resolved": "https://registry.npmjs.org/keep-alive-agent/-/keep-alive-agent-0.0.1.tgz"
+          "from": "keep-alive-agent@0.0.1"
         },
         "lru-cache": {
           "version": "2.3.1",
-          "from": "lru-cache@2.3.1",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.3.1.tgz"
+          "from": "lru-cache@2.3.1"
         },
         "mime": {
           "version": "1.2.11",
-          "from": "mime@1.2.11",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+          "from": "mime@1.2.11"
         },
         "negotiator": {
           "version": "0.3.0",
-          "from": "negotiator@0.3.0",
-          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.3.0.tgz"
+          "from": "negotiator@0.3.0"
         },
         "node-uuid": {
           "version": "1.4.1",
-          "from": "node-uuid@1.4.1",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.1.tgz"
+          "from": "node-uuid@1.4.1"
         },
         "once": {
           "version": "1.3.0",
-          "from": "once@1.3.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.3.0.tgz"
+          "from": "once@1.3.0"
         },
         "qs": {
           "version": "0.6.6",
-          "from": "qs@0.6.6",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
+          "from": "qs@0.6.6"
         },
         "semver": {
           "version": "2.2.1",
-          "from": "semver@2.2.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-2.2.1.tgz"
+          "from": "semver@2.2.1"
         },
         "spdy": {
           "version": "1.19.3",
-          "from": "spdy@1.19.3",
-          "resolved": "https://registry.npmjs.org/spdy/-/spdy-1.19.3.tgz"
+          "from": "spdy@1.19.3"
         },
         "tunnel-agent": {
           "version": "0.4.0",
-          "from": "tunnel-agent@0.4.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+          "from": "tunnel-agent@0.4.0"
         },
         "verror": {
           "version": "1.3.7",
           "from": "verror@1.3.7",
-          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.7.tgz",
           "dependencies": {
             "extsprintf": {
               "version": "1.0.2",
-              "from": "extsprintf@1.0.2",
-              "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+              "from": "extsprintf@1.0.2"
             }
           }
         },
         "dtrace-provider": {
           "version": "0.2.8",
-          "from": "dtrace-provider@0.2.8",
-          "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.2.8.tgz"
+          "from": "dtrace-provider@0.2.8"
         }
       }
     },
     "tap": {
       "version": "0.4.9",
       "from": "tap@0.4.9",
-      "resolved": "https://registry.npmjs.org/tap/-/tap-0.4.9.tgz",
       "dependencies": {
         "inherits": {
           "version": "2.0.1",
@@ -1533,33 +841,27 @@
         },
         "slide": {
           "version": "1.1.5",
-          "from": "slide@*",
-          "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.5.tgz"
+          "from": "slide@*"
         },
         "runforcover": {
           "version": "0.0.2",
           "from": "runforcover@~0.0.2",
-          "resolved": "https://registry.npmjs.org/runforcover/-/runforcover-0.0.2.tgz",
           "dependencies": {
             "bunker": {
               "version": "0.1.2",
               "from": "bunker@0.1.X",
-              "resolved": "https://registry.npmjs.org/bunker/-/bunker-0.1.2.tgz",
               "dependencies": {
                 "burrito": {
                   "version": "0.2.12",
                   "from": "burrito@>=0.2.5 <0.3",
-                  "resolved": "https://registry.npmjs.org/burrito/-/burrito-0.2.12.tgz",
                   "dependencies": {
                     "traverse": {
                       "version": "0.5.2",
-                      "from": "traverse@~0.5.1",
-                      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.5.2.tgz"
+                      "from": "traverse@~0.5.1"
                     },
                     "uglify-js": {
                       "version": "1.1.1",
-                      "from": "uglify-js@~1.1.1",
-                      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-1.1.1.tgz"
+                      "from": "uglify-js@~1.1.1"
                     }
                   }
                 }
@@ -1570,76 +872,62 @@
         "nopt": {
           "version": "2.2.1",
           "from": "nopt@~2",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.2.1.tgz",
           "dependencies": {
             "abbrev": {
               "version": "1.0.5",
-              "from": "abbrev@1",
-              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+              "from": "abbrev@1"
             }
           }
         },
         "mkdirp": {
           "version": "0.3.5",
-          "from": "mkdirp@~0.3",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+          "from": "mkdirp@~0.3"
         },
         "difflet": {
           "version": "0.2.6",
           "from": "difflet@~0.2.0",
-          "resolved": "https://registry.npmjs.org/difflet/-/difflet-0.2.6.tgz",
           "dependencies": {
             "traverse": {
               "version": "0.6.6",
-              "from": "traverse@0.6.x",
-              "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz"
+              "from": "traverse@0.6.x"
             },
             "charm": {
               "version": "0.1.2",
-              "from": "charm@0.1.x",
-              "resolved": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz"
+              "from": "charm@0.1.x"
             },
             "deep-is": {
               "version": "0.1.2",
-              "from": "deep-is@0.1.x",
-              "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.2.tgz"
+              "from": "deep-is@0.1.x"
             }
           }
         },
         "deep-equal": {
           "version": "0.0.0",
-          "from": "deep-equal@~0.0.0",
-          "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.0.0.tgz"
+          "from": "deep-equal@~0.0.0"
         },
         "buffer-equal": {
           "version": "0.0.1",
-          "from": "buffer-equal@~0.0.0",
-          "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz"
+          "from": "buffer-equal@~0.0.0"
         },
         "glob": {
           "version": "3.2.11",
-          "from": "glob@~3.2.9",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+          "from": "glob@~3.2.1",
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@2",
-              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+              "from": "inherits@2"
             },
             "minimatch": {
               "version": "0.3.0",
               "from": "minimatch@0.3",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
               "dependencies": {
                 "lru-cache": {
                   "version": "2.5.0",
-                  "from": "lru-cache@2",
-                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                  "from": "lru-cache@2"
                 },
                 "sigmund": {
                   "version": "1.0.0",
-                  "from": "sigmund@~1.0.0",
-                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                  "from": "sigmund@~1.0.0"
                 }
               }
             }
@@ -1649,8 +937,7 @@
     },
     "uuid": {
       "version": "1.4.1",
-      "from": "uuid@1.4.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-1.4.1.tgz"
+      "from": "uuid@1.4.1"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "restify": "2.7.0"
   },
   "devDependencies": {
-    "ass": "git://github.com/dannycoates/ass.git#7d131b5769",
+    "ass": "git://github.com/jrgm/ass.git#2e9a9922f2",
     "grunt": "0.4.5",
     "grunt-contrib-jshint": "0.10.0",
     "grunt-copyright": "0.1.0",


### PR DESCRIPTION
I want to propose merging https://github.com/jrgm/ass/tree/debadge into lloyd/master version, and this is a first step towards that. 
