### PR TITLE
pass err.stack so bunyan actually prints more than "uncaughtException"

### DIFF
--- a/bin/db_server.js
+++ b/bin/db_server.js
@@ -32,7 +32,7 @@ process.on(
   function (err) {
     log.fatal({
       op: 'uncaughtException',
-      err: err
+      err: (err && err.stack) || err
     })
     process.exit(8)
   }


### PR DESCRIPTION
I was set up with the wrong value of patchLevel in my config so the server was crashing at startup. Unfortunately, all the error log would say was '"level":60,"op":"uncaughtException","err": {},"msg":"" ...'
which is not the most useful. This change will result in the full stack and root cause ("Error: dbIncorrectPatchLevel") being shown.
