### PR TITLE
fix(db): Change the behaviour of the DB server so that a patch level mis-match is only logged, fixes #114 for train-29

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
 train-29
+  * Change the behaviour of the DB server so that a patch level
+    mis-match is only logged - #114
   * Add a CONTRIBUTING.md and an AUTHORS file - #104, #117
   * Remove references to the old .fxa_dbrc config file - #107, #113
   * Failed stored procedures return errors correctly - #95, #94

--- a/db/mysql.js
+++ b/db/mysql.js
@@ -127,7 +127,17 @@ module.exports = function (log, error) {
             return mysql
           }
 
-          throw new Error('dbIncorrectPatchLevel')
+          // https://github.com/mozilla/fxa-auth-db-server/issues/114
+          // Change the behaviour of the DB server so that a patch level
+          // mis-match is only logged. NOTE: this is a minimal change,
+          // only for the train-29 branch.
+          log.warn({
+            op: 'MySql.connect',
+            patchLevel: mysql.patchLevel,
+            patchLevelRequired: patch.level
+          })
+
+          return mysql
         }
       )
   }

--- a/test/local/incorrect-patch-level.js
+++ b/test/local/incorrect-patch-level.js
@@ -5,7 +5,7 @@ require('ass')
 var test = require('tap').test
 var error = require('../../error')
 var config = require('../../config')
-var log = { trace: console.log, error: console.log, stat: console.log, info: console.log }
+var log = { trace: console.log, error: console.log, stat: console.log, info: console.log, warn: console.log }
 var patch = require('../../db/patch')
 var DB = require('../../db/mysql')(log, error)
 
@@ -17,7 +17,7 @@ DB.connect(config)
       test(
         'the connect should fail and we will never get here',
         function (t) {
-          t.fail('DB.connect should have failed on an incorrect patchVersion')
+          // t.fail('DB.connect should have failed on an incorrect patchVersion')
           t.end()
           db.close()
         }


### PR DESCRIPTION
@chilts - I had been using a snapshot build in stage with this, but hadn't got around to getting this in and branched. r? 