### PR TITLE
fix(db): set createdAt, verifierSetAt and normalizedEmail in the tests

### DIFF
--- a/test/fake.js
+++ b/test/fake.js
@@ -33,8 +33,10 @@ module.exports.newUserDataHex = function() {
     authSalt: hex32(),
     kA: hex32(),
     wrapWrapKb: hex32(),
-    verifierSetAt: Date.now()
+    verifierSetAt: Date.now(),
+    createdAt: Date.now(),
   }
+  data.account.normalizedEmail = data.account.email.toLowerCase()
 
   // sessionToken
   data.sessionTokenId = hex32()
@@ -98,8 +100,10 @@ module.exports.newUserDataBuffer = function() {
     authSalt: buf32(),
     kA: buf32(),
     wrapWrapKb: buf32(),
-    verifierSetAt: Date.now()
+    verifierSetAt: Date.now(),
+    createdAt: Date.now(),
   }
+  data.account.normalizedEmail = data.account.email.toLowerCase()
 
   // sessionToken
   data.sessionTokenId = buf32()


### PR DESCRIPTION
The fxa-auth-server always sets these fields, so we should simulate that here
so that the backends perform the correct functionality.