### PR TITLE
refactor(tests): Generate test UIDs a different way

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "grunt-contrib-jshint": "0.10.0",
     "grunt-copyright": "0.1.0",
     "load-grunt-tasks": "0.6.0",
-    "node-uuid": "1.4.3",
     "tap": "0.4.12"
   },
   "keywords": [],

--- a/test/backend/db_tests.js
+++ b/test/backend/db_tests.js
@@ -3,15 +3,12 @@
 
 var test = require('../ptaptest')
 var crypto = require('crypto')
-var uuid = require('node-uuid')
 
 var zeroBuffer16 = Buffer('00000000000000000000000000000000', 'hex')
 var zeroBuffer32 = Buffer('0000000000000000000000000000000000000000000000000000000000000000', 'hex')
 
 function newUuid() {
-  // This seems to be a weird way to get the uuid in a buffer:
-  // * https://github.com/broofa/node-uuid#uuidv4options--buffer--offset
-  return uuid.v4(null, new Buffer(16))
+  return crypto.randomBytes(16)
 }
 
 var now = Date.now()


### PR DESCRIPTION
Since we have weird dependency issues related to how the reverse backends work
it may be better off to remove uuid/node-uuid completely so we don't have to
solve it in a weird way. This actually ends up slightly cleaner too, though
we may still have to solve this issue at some point in the future. See
https://github.com/mozilla/fxa-auth-db-mem/issues/23#issuecomment-93856934
for further details.