### PR TITLE
fix(db): ensure that requests for bad paths are logged, fixes #144

### DIFF
--- a/test/backend/remote.js
+++ b/test/backend/remote.js
@@ -549,6 +549,77 @@ module.exports = function(cfg) {
   )
 
   test(
+    'bad get',
+    function (t) {
+      client.getThen('/foobar')
+        .then(function(r) {
+          t.fail('This request should have failed (instead it suceeded)')
+          t.end()
+        }, function(err) {
+          testNotFound(t, err)
+          t.end()
+        })
+    }
+  )
+
+  test(
+    'bad put',
+    function (t) {
+      client.putThen('/foobar', {})
+        .then(function(r) {
+          t.fail('This request should have failed (instead it suceeded)')
+          t.end()
+        }, function(err) {
+          testNotFound(t, err)
+          t.end()
+        })
+    }
+  )
+
+  test(
+    'bad post',
+    function (t) {
+      client.postThen('/foobar', {})
+        .then(function(r) {
+          t.fail('This request should have failed (instead it suceeded)')
+          t.end()
+        }, function(err) {
+          testNotFound(t, err)
+          t.end()
+        })
+    }
+  )
+
+  test(
+    'bad delete',
+    function (t) {
+      client.delThen('/foobar')
+        .then(function(r) {
+          t.fail('This request should have failed (instead it suceeded)')
+          t.end()
+        }, function(err) {
+          testNotFound(t, err)
+          t.end()
+        })
+    }
+  )
+
+  test(
+    'bad head',
+    function (t) {
+      client.headThen('/foobar')
+        .then(function(r) {
+          t.fail('This request should have failed (instead it suceeded)')
+          t.end()
+        }, function(err) {
+
+          t.deepEqual(err.body, {}, 'Body contains nothing since this is a HEAD request')
+          t.end()
+        })
+    }
+  )
+
+  test(
     'teardown',
     function (t) {
       d.resolve()


### PR DESCRIPTION
I made some assumptions here, so I have questions:

1. I've assumed that whatever is listening for the `'failure'` event is the thing that does the actual logging. Is that correct? Which repo is listening for that event? I tried grepping in a few but didn't find anything.

2. I've not used restify before but couldn't see a better way in the docs to do what I've done in `index.js`. The identical sequential calls to `get()`, `put()`, `post()`, `delete()` and `head()` are a bit smelly, is there any way to wildcard the HTTP verb in restify?

3. There's also an assumption in the general approach I've taken, I'm not sure if it's what you guys had in mind. Obviously I extracted the code in `handleError` to a named function for re-use, but I wasn't sure if that justified extracting the `resolve` handler to a named function too. Doing so would make the async call more uniform and improve readability I reckon, but it's not called from anywhere else so perhaps it's a bit OTT. What do you think?

@chilts @rfk: r?
