### PR TITLE
feat(db): store user agent and last-access time in sessionTokens

### DIFF
--- a/docs/DB_API.md
+++ b/docs/DB_API.md
@@ -15,6 +15,7 @@ There are a number of methods that a DB storage backend should implement:
     * .accountExists(emailBuffer)
 * Session Tokens
     * .createSessionToken(tokenId, sessionToken)
+    * .updateSessionToken(tokenId, sessionToken)
     * .sessionToken(id)
     * .deleteSessionToken(tokenId)
 * Key Fetch Tokens
@@ -249,7 +250,7 @@ Parameters.
 
 Each token takes the following fields for it's create method respectively:
 
-* sessionToken : data, uid, createdAt
+* sessionToken : data, uid, createdAt, userAgent, lastAccessTime
 * keyFetchToken : authKey, uid, keyBundle, createdAt
 * passwordChangeToken : data, uid, createdAt
 * passwordForgotToken : data, uid, passCode, createdAt, triesxb
@@ -288,7 +289,7 @@ Returns:
 Each token returns different fields. These fields are represented as `t.*` for a field
 from the token and `a.*` for a field from the corresponding account.
 
-* sessionToken : t.tokenData, t.uid, t.createdAt, a.emailVerified, a.email, a.emailCode, a.verifierSetAt
+* sessionToken : t.tokenData, t.uid, t.createdAt, t.userAgent, t.lastAccessTime, a.emailVerified, a.email, a.emailCode, a.verifierSetAt
 * keyFetchToken : t.authKey, t.uid, t.keyBundle, t.createdAt, a.emailVerified, a.verifierSetAt
 * passwordChangeToken : t.tokenData, t.uid, t.createdAt, a.verifierSetAt
 * passwordForgotToken : t.tokenData, t.uid, t.createdAt, t.passCode, t.tries, a.email, a.verifierSetAt
@@ -301,6 +302,24 @@ from the token and `a.*` for a field from the corresponding account.
 ### .deleteAccountResetToken(tokenId) ###
 
 Will delete the token of the correct type designated by the given `tokenId`.
+
+## .updateSessionToken(tokenId, token) ##
+
+An extra function for `sessionTokens`. Just updates the `userAgent` and `lastAccessTime` fields of the token.
+
+Parameters.
+
+* tokenId : (Buffer32) the unique id for this token
+* token : (Object) -
+    * userAgent : (string)
+    * lastAccessTime : (number)
+
+Returns:
+
+* resolves with:
+    * an object `{}` (whether a row was updated or not, ie. even if `tokenId` does not exist.)
+* rejects with:
+    * any error from the underlying storage system (wrapped in `error.wrap()`)
 
 ## .updatePasswordForgotToken(tokenId, token) ##
 
@@ -317,7 +336,7 @@ Returns:
 * resolves with:
     * an object `{}` (whether a row was updated or not, ie. even if `tokenId` does not exist.)
 * rejects with:
-    * any error from the underlying storage system (wrapped in `error.wrap()`
+    * any error from the underlying storage system (wrapped in `error.wrap()`)
 
 ## .forgotPasswordVerified(tokenId, accountResetToken) ##
 

--- a/docs/Server_API.md
+++ b/docs/Server_API.md
@@ -61,6 +61,7 @@ The following datatypes are used throughout this document:
     * sessionToken              : `GET /sessionToken/:id`
     * deleteSessionToken        : `DEL /sessionToken/:id`
     * createSessionToken        : `PUT /sessionToken/:id`
+    * updateSessionToken        : `POST /sessionToken/:id/update`
 * Account Reset Tokens:
     * accountResetToken         : `GET /accountResetToken/:id`
     * deleteAccountResetToken   : `DEL /accountResetToken/:id`
@@ -482,6 +483,55 @@ Content-Length: 2
     * Content-Type : 'application/json'
     * Body : {"code":"InternalError","message":"...<message related to the error>..."}
 
+## updateSessionToken : `POST /sessionToken/<tokenId>/update`
+
+This updates the user agent and last-access time for a particular token.
+
+### Example
+
+```
+curl \
+    -v \
+    -X POST \
+    -H "Content-Type: application/json" \
+    -d '{
+        "userAgent" : "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:41.0) Gecko/20100101 Firefox/41.0",
+		"lastAccessTime": 1437992394186
+    }' \
+    http://localhost:8000/sessionToken/522c251a1623e1f1db1f4fe68b9594d26772d6e77e04cb68e110c58600f97a77/update
+```
+
+### Request
+
+* Method : POST
+* Path : `/sessionToken/<tokenId>/update`
+    * tokenId : hex256
+* Params:
+    * userAgent : string
+    * lastAccessTime : epoch
+
+### Response
+
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 2
+
+{}
+```
+
+* Status Code : 200 OK
+    * Content-Type : 'application/json'
+    * Body : {}
+* Status Code : 404 Not Found
+    * Conditions: if this session `tokenId` doesn't exist
+    * Content-Type : 'application/json'
+    * Body : `{"message":"Not Found"}`
+* Status Code : 500 Internal Server Error
+    * Conditions: if something goes wrong on the server
+    * Content-Type : 'application/json'
+    * Body : `{"code":"InternalError","message":"...<message related to the error>..."}`
+
 
 ## accountDevices : `GET /account/<uid>/devices`
 
@@ -529,7 +579,6 @@ Content-Length: 564
     * Conditions: if something goes wrong on the server
     * Content-Type : 'application/json'
     * Body : `{"code":"InternalError","message":"...<message related to the error>..."}`
-
 
 ## sessionToken : `GET /sessionToken/<tokenId>`
 
@@ -1199,7 +1248,7 @@ curl \
 
 ### Request
 
-* Method : PUT
+* Method : POST
 * Path : `/passwordForgotToken/<tokenId>/update`
     * tokenId : hex256
 * Params:

--- a/index.js
+++ b/index.js
@@ -83,6 +83,7 @@ function createServer(db) {
   api.get('/sessionToken/:id', reply(db.sessionToken))
   api.del('/sessionToken/:id', reply(db.deleteSessionToken))
   api.put('/sessionToken/:id', reply(db.createSessionToken))
+  api.post('/sessionToken/:id/update', reply(db.updateSessionToken))
 
   api.get('/keyFetchToken/:id', reply(db.keyFetchToken))
   api.del('/keyFetchToken/:id', reply(db.deleteKeyFetchToken))

--- a/test/fake.js
+++ b/test/fake.js
@@ -43,7 +43,9 @@ module.exports.newUserDataHex = function() {
   data.sessionToken = {
     data : hex32(),
     uid : data.accountId,
-    createdAt: Date.now()
+    createdAt: Date.now(),
+    userAgent: 'fake user agent string',
+    lastAccessTime: Date.now()
   }
 
   // keyFetchToken
@@ -110,7 +112,9 @@ module.exports.newUserDataBuffer = function() {
   data.sessionToken = {
     data : buf32(),
     uid : data.accountId,
-    createdAt: Date.now()
+    createdAt: Date.now(),
+    userAgent: '',
+    lastAccessTime: 0
   }
 
   // keyFetchToken


### PR DESCRIPTION
Partially addresses https://github.com/mozilla/fxa-auth-server/issues/983.

Depends on:

* https://github.com/mozilla/fxa-auth-db-mysql/pull/65
* https://github.com/mozilla/fxa-auth-db-mem/pull/43
* https://github.com/mozilla/fxa-auth-server/pull/997

Adds the endpoint `POST /sessionToken/:id/update`.
